### PR TITLE
✅ Make Sendinblue more testable. 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
     },
     "require-dev": {
         "mockery/mockery": "^1.2",
-        "phpunit/phpunit": "^7.0"
+        "orchestra/testbench": "^4.0",
+        "phpunit/phpunit": "^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Sendinblue.php
+++ b/src/Sendinblue.php
@@ -28,8 +28,8 @@ class Sendinblue
      */
     public function __construct(AccountApi $accountApi, ContactsApi $contactsApi, AttributesApi $attributesApi)
     {
-        $this->accountApi    = $accountApi;
-        $this->contactsApi   = $contactsApi;
+        $this->accountApi = $accountApi;
+        $this->contactsApi = $contactsApi;
         $this->attributesApi = $attributesApi;
     }
 

--- a/src/Sendinblue.php
+++ b/src/Sendinblue.php
@@ -33,7 +33,6 @@ class Sendinblue
         $this->attributesApi = $attributesApi;
     }
 
-
     /**
      * Get account information.
      *

--- a/src/Sendinblue.php
+++ b/src/Sendinblue.php
@@ -13,12 +13,6 @@ class Sendinblue
 {
     use Api;
 
-    /** @var Client */
-    private $client;
-
-    /** @var Configuration */
-    private $config = null;
-
     /** @var AccountApi */
     private $accountApi = null;
 
@@ -28,22 +22,19 @@ class Sendinblue
     /** @var AttributesApi */
     private $attributesApi = null;
 
-    public function __construct(Client $client)
-    {
-        $this->client = $client;
-    }
-
     /**
-     * @return Configuration
+     * Sendinblue constructor.
+     * @param AccountApi    $accountApi
+     * @param ContactsApi   $contactsApi
+     * @param AttributesApi $attributesApi
      */
-    private function getConfiguration()
+    public function __construct(AccountApi $accountApi, ContactsApi $contactsApi, AttributesApi $attributesApi)
     {
-        if (null === $this->config) {
-            $this->config = Configuration::getDefaultConfiguration()->setApiKey('api-key', Config::get('sendinblue.apiKey'));
-        }
-
-        return $this->config;
+        $this->accountApi    = $accountApi;
+        $this->contactsApi   = $contactsApi;
+        $this->attributesApi = $attributesApi;
     }
+
 
     /**
      * Get account information.

--- a/src/Sendinblue.php
+++ b/src/Sendinblue.php
@@ -2,12 +2,9 @@
 
 namespace Damcclean\Sendinblue;
 
-use GuzzleHttp\Client;
-use Illuminate\Support\Facades\Config;
 use SendinBlue\Client\Api\AccountApi;
 use SendinBlue\Client\Api\AttributesApi;
 use SendinBlue\Client\Api\ContactsApi;
-use SendinBlue\Client\Configuration;
 
 class Sendinblue
 {
@@ -24,6 +21,7 @@ class Sendinblue
 
     /**
      * Sendinblue constructor.
+     *
      * @param AccountApi    $accountApi
      * @param ContactsApi   $contactsApi
      * @param AttributesApi $attributesApi

--- a/src/SendinblueServiceProvider.php
+++ b/src/SendinblueServiceProvider.php
@@ -28,27 +28,32 @@ class SendinblueServiceProvider extends ServiceProvider
         $this->app->singleton('sendinblue.client', function () {
             return new Client();
         });
+
         $this->app->singleton('sendinblue.config', function () {
             return Configuration::getDefaultConfiguration()->setApiKey('api-key', Config::get('sendinblue.apiKey'));
         });
+
         $this->app->singleton(AccountApi::class, function ($app) {
             $client = $app->make('sendinblue.client');
             $config = $app->make('sendinblue.config');
 
             return new AccountApi($client, $config);
         });
+
         $this->app->singleton(ContactsApi::class, function ($app) {
             $client = $app->make('sendinblue.client');
             $config = $app->make('sendinblue.config');
 
             return new ContactsApi($client, $config);
         });
+
         $this->app->singleton(AttributesApi::class, function ($app) {
             $client = $app->make('sendinblue.client');
             $config = $app->make('sendinblue.config');
 
             return new AttributesApi($client, $config);
         });
+
         $this->app->bind('sendinblue', Sendinblue::class);
     }
 }

--- a/src/SendinblueServiceProvider.php
+++ b/src/SendinblueServiceProvider.php
@@ -3,7 +3,12 @@
 namespace Damcclean\Sendinblue;
 
 use GuzzleHttp\Client;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\ServiceProvider;
+use SendinBlue\Client\Api\AccountApi;
+use SendinBlue\Client\Api\AttributesApi;
+use SendinBlue\Client\Api\ContactsApi;
+use SendinBlue\Client\Configuration;
 
 class SendinblueServiceProvider extends ServiceProvider
 {
@@ -20,8 +25,27 @@ class SendinblueServiceProvider extends ServiceProvider
     {
         $this->mergeConfigFrom(__DIR__.'/../config/config.php', 'sendinblue');
 
-        $this->app->singleton('sendinblue', function () {
-            return new Sendinblue(new Client());
+        $this->app->singleton('sendinblue.client', function () {
+            return new Client();
         });
+        $this->app->singleton('sendinblue.config', function () {
+            return Configuration::getDefaultConfiguration()->setApiKey('api-key', Config::get('sendinblue.apiKey'));
+        });
+        $this->app->singleton(AccountApi::class, function ($app) {
+            $client = $app->make('sendinblue.client');
+            $config = $app->make('sendinblue.config');
+            return new AccountApi($client, $config);
+        });
+        $this->app->singleton(ContactsApi::class, function ($app) {
+            $client = $app->make('sendinblue.client');
+            $config = $app->make('sendinblue.config');
+            return new ContactsApi($client, $config);
+        });
+        $this->app->singleton(AttributesApi::class, function ($app) {
+            $client = $app->make('sendinblue.client');
+            $config = $app->make('sendinblue.config');
+            return new AttributesApi($client, $config);
+        });
+        $this->app->bind('sendinblue', Sendinblue::class);
     }
 }

--- a/src/SendinblueServiceProvider.php
+++ b/src/SendinblueServiceProvider.php
@@ -34,16 +34,19 @@ class SendinblueServiceProvider extends ServiceProvider
         $this->app->singleton(AccountApi::class, function ($app) {
             $client = $app->make('sendinblue.client');
             $config = $app->make('sendinblue.config');
+
             return new AccountApi($client, $config);
         });
         $this->app->singleton(ContactsApi::class, function ($app) {
             $client = $app->make('sendinblue.client');
             $config = $app->make('sendinblue.config');
+
             return new ContactsApi($client, $config);
         });
         $this->app->singleton(AttributesApi::class, function ($app) {
             $client = $app->make('sendinblue.client');
             $config = $app->make('sendinblue.config');
+
             return new AttributesApi($client, $config);
         });
         $this->app->bind('sendinblue', Sendinblue::class);

--- a/tests/SendinblueTest.php
+++ b/tests/SendinblueTest.php
@@ -15,7 +15,6 @@ use SendinBlue\Client\Model\GetLists;
 
 class SendinblueTest extends TestCase
 {
-
     /**
      * @return \Damcclean\Sendinblue\Sendinblue
      */
@@ -23,6 +22,7 @@ class SendinblueTest extends TestCase
     {
         $instance = app('sendinblue');
         $this->assertInstanceOf(\Damcclean\Sendinblue\Sendinblue::class, $instance);
+
         return $instance;
     }
 
@@ -81,6 +81,7 @@ class SendinblueTest extends TestCase
             'attributes' => $attributes,
             'listIds'    => $listIds,
         ]);
+
         return [
             'create_contact_with_email'      => [$contactData->only('email')],
             'create_contact_with_attributes' => [$contactData->only('email', 'attributes')],
@@ -111,7 +112,6 @@ class SendinblueTest extends TestCase
                 $contactData->get('listIds')
             );
         $this->assertEquals($expectedContact, $newContact);
-
     }
 
     /** @test */

--- a/tests/SendinblueTest.php
+++ b/tests/SendinblueTest.php
@@ -21,6 +21,7 @@ class SendinblueTest extends TestCase
     private function getSendinblue()
     {
         $instance = app('sendinblue');
+
         $this->assertInstanceOf(\Damcclean\Sendinblue\Sendinblue::class, $instance);
 
         return $instance;
@@ -40,6 +41,7 @@ class SendinblueTest extends TestCase
             ->once()
             ->andReturn('api-key');
         $configuration = app('sendinblue.config');
+
         $this->assertInstanceOf(Configuration::class, $configuration);
         $this->assertEquals('api-key', $configuration->getApiKey('api-key'));
     }
@@ -48,6 +50,7 @@ class SendinblueTest extends TestCase
     public function can_get_account()
     {
         $response = $this->getSendinblue()->getAccount();
+
         $this->assertInstanceOf(GetAccount::class, $response);
     }
 
@@ -111,6 +114,7 @@ class SendinblueTest extends TestCase
                 $contactData->get('attributes'),
                 $contactData->get('listIds')
             );
+
         $this->assertEquals($expectedContact, $newContact);
     }
 

--- a/tests/SendinblueTest.php
+++ b/tests/SendinblueTest.php
@@ -73,18 +73,18 @@ class SendinblueTest extends TestCase
 
     public function createContactScenarios()
     {
-        $email = 'sendinblue@example.com';
+        $email      = 'sendinblue@example.com';
         $attributes = ['attribute1', 'attribute2', 'attribute3'];
-        $listIds = ['id', 'id2'];
+        $listIds    = ['id', 'id2'];
         $contactData = collect([
-            'email' => $email,
+            'email'      => $email,
             'attributes' => $attributes,
-            'listIds' => $listIds
+            'listIds'    => $listIds
         ]);
         return [
-            'create_contact_with_email' => [$contactData->only('email')],
+            'create_contact_with_email'      => [$contactData->only('email')],
             'create_contact_with_attributes' => [$contactData->only('email', 'attributes')],
-            'create_contact_with_listIds' => [$contactData->only('email', 'listIds')],
+            'create_contact_with_listIds'    => [$contactData->only('email', 'listIds')],
             'create_contact_with_all_values' => [$contactData->only('email', 'attributes', 'listIds')]
         ];
     }

--- a/tests/SendinblueTest.php
+++ b/tests/SendinblueTest.php
@@ -222,4 +222,3 @@ class SendinblueTest extends TestCase
         //
     }
 }
-

--- a/tests/SendinblueTest.php
+++ b/tests/SendinblueTest.php
@@ -73,19 +73,19 @@ class SendinblueTest extends TestCase
 
     public function createContactScenarios()
     {
-        $email      = 'sendinblue@example.com';
+        $email = 'sendinblue@example.com';
         $attributes = ['attribute1', 'attribute2', 'attribute3'];
-        $listIds    = ['id', 'id2'];
+        $listIds = ['id', 'id2'];
         $contactData = collect([
             'email'      => $email,
             'attributes' => $attributes,
-            'listIds'    => $listIds
+            'listIds'    => $listIds,
         ]);
         return [
             'create_contact_with_email'      => [$contactData->only('email')],
             'create_contact_with_attributes' => [$contactData->only('email', 'attributes')],
             'create_contact_with_listIds'    => [$contactData->only('email', 'listIds')],
-            'create_contact_with_all_values' => [$contactData->only('email', 'attributes', 'listIds')]
+            'create_contact_with_all_values' => [$contactData->only('email', 'attributes', 'listIds')],
         ];
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Damcclean\Sendinblue\Tests;
 
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,7 +2,6 @@
 
 namespace Damcclean\Sendinblue\Tests;
 
-
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,31 @@
+<?php
+namespace Damcclean\Sendinblue\Tests;
+
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use Illuminate\Support\Facades\Config;
+
+class TestCase extends \Orchestra\Testbench\TestCase
+{
+    protected function getPackageProviders($app)
+    {
+        return [\Damcclean\Sendinblue\SendinblueServiceProvider::class];
+    }
+
+    protected function mockHttpResponse($status, $body)
+    {
+        $mock = new MockHandler([new Response($status, [], $body)]);
+        $handler = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handler]);
+
+        app()->instance('sendinblue.client', $client);
+    }
+
+    protected function configProvideApiKey()
+    {
+        Config::set('sendinblue.apiKey', 'api-key');
+    }
+}


### PR DESCRIPTION
Make Sendinblue more testable. 
provide sdk instances from dependency container. 

Add test create contact #8 

Use orchestra/testbench to fake laravel application to use service providers and dependency injection.